### PR TITLE
Updated to be compatible with v0.2.0 of the smart-leds crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ws2812-nop-samd21"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Paul Sajna <sajattack@gmail.com>"]
 edition = "2018"
 description = "Nop-based bitbanger for 48MHz SAMD21 devices"
@@ -14,15 +14,15 @@ categories = [
 keywords = ["smart-leds", "ws2812", "driver", "atsamd"]
 
 [dependencies]
-smart-leds-trait = "~0.1" 
-cortex-m = "~0.5"
+smart-leds-trait = "~0.2" 
+cortex-m = "~0.6"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
 version = "~0.2"
 
 [dev-dependencies]
-circuit_playground_express = "~0.2"
+circuit_playground_express = "~0.3"
 cortex-m-rt = "~0.6"
 panic-halt = "~0.2"
-smart-leds = "~0.1"
+smart-leds = "~0.2"

--- a/examples/rainbow.rs
+++ b/examples/rainbow.rs
@@ -14,9 +14,9 @@ use hal::delay::Delay;
 use hal::prelude::*;
 use hal::{CorePeripherals, Peripherals};
 
-use smart_leds::brightness;
-use smart_leds_trait::Color;
-use smart_leds_trait::SmartLedsWrite;
+use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::hsv::RGB8;
+
 use ws2812::Ws2812;
 
 #[entry]
@@ -36,7 +36,7 @@ fn main() -> ! {
     let mut neopixel = Ws2812::new(neopixel_pin);
 
     const NUM_LEDS: usize = 10;
-    let mut data = [Color::default(); NUM_LEDS];
+    let mut data = [RGB8::default(); NUM_LEDS];
 
     loop {
         for j in 0..(256 * 5) {
@@ -53,7 +53,7 @@ fn main() -> ! {
 
 /// Input a value 0 to 255 to get a color value
 /// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> Color {
+fn wheel(mut wheel_pos: u8) -> RGB8 {
     wheel_pos = 255 - wheel_pos;
     if wheel_pos < 85 {
         return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -14,8 +14,9 @@ use hal::delay::Delay;
 use hal::prelude::*;
 use hal::{CorePeripherals, Peripherals};
 
-use smart_leds_trait::Color;
-use smart_leds_trait::SmartLedsWrite;
+use smart_leds::SmartLedsWrite;
+use smart_leds::hsv::RGB8;
+
 use ws2812::Ws2812;
 
 #[entry]
@@ -37,7 +38,7 @@ fn main() -> ! {
     const MAX: usize = 10;
     const COLOR1: (u8, u8, u8) = (0x00, 0xc3 / 5, 0x36 / 5);
     const COLOR2: (u8, u8, u8) = (0x00, 0x24 / 5, 0xb0 / 5);
-    let mut data = [Color::default(); MAX];
+    let mut data = [RGB8::default(); MAX];
     let mut main = 0;
     let mut up = true;
 

--- a/examples/smile.rs
+++ b/examples/smile.rs
@@ -12,9 +12,10 @@ extern crate ws2812_nop_samd21 as ws2812;
 use hal::clock::GenericClockController;
 use hal::Peripherals;
 
+use smart_leds::SmartLedsWrite;
+use smart_leds::hsv::RGB8;
 use smart_leds::colors::YELLOW;
-use smart_leds_trait::Color;
-use smart_leds_trait::SmartLedsWrite;
+
 use ws2812::Ws2812;
 
 #[entry]
@@ -32,7 +33,7 @@ fn main() -> ! {
     let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
     let mut neopixel = Ws2812::new(neopixel_pin);
 
-    let off = Color::default();
+    let off = RGB8::default();
     let smile = [
         YELLOW, off, YELLOW, YELLOW, YELLOW, YELLOW, YELLOW, YELLOW, off, YELLOW,
     ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![feature(asm)]
 
-use embedded_hal::digital::OutputPin;
-use smart_leds_trait::{Color, SmartLedsWrite};
+use embedded_hal::digital::v2::OutputPin;
+use smart_leds_trait::{RGB8, SmartLedsWrite};
 
 pub struct Ws2812<P: OutputPin> {
     pin: P,
@@ -15,15 +15,15 @@ impl<P: OutputPin> Ws2812<P> {
     fn write_byte(&mut self, data: u8) {
         let mut bitmask: u8 = 0x80;
         while bitmask != 0 {
-            self.pin.set_high();
+            self.pin.set_high().unwrap_or(());
             unsafe {
                 asm!("nop; nop;");
             }
             if data & bitmask != 0 {
                 unsafe { asm!("nop; nop; nop; nop; nop; nop; nop;") }
-                self.pin.set_low();
+                self.pin.set_low().unwrap_or(());
             } else {
-                self.pin.set_low();
+                self.pin.set_low().unwrap_or(());
                 unsafe {
                     asm!("nop; nop;");
                 }
@@ -40,15 +40,18 @@ impl<P> SmartLedsWrite for Ws2812<P>
 where
     P: OutputPin,
 {
+    type Color = RGB8;
     type Error = ();
-    fn write<T>(&mut self, iterator: T) -> Result<(), ()>
+    fn write<T, I>(&mut self, iterator: T) -> Result<(), ()>
     where
-        T: Iterator<Item = Color>,
+        T: Iterator<Item = I>,
+        I: Into<Self::Color>
     {
         for item in iterator {
-            self.write_byte(item.g);
-            self.write_byte(item.r);
-            self.write_byte(item.b);
+            let color: Self::Color = item.into();
+            self.write_byte(color.g);
+            self.write_byte(color.r);
+            self.write_byte(color.b);
         }
         Ok(())
     }


### PR DESCRIPTION
Hello!

I went to use your crate with the circuit playground express board support package, and there seemed to be some version incompatibilities.

I've updated your library and its examples to be compatible with the latest versions of:
* `smart-leds`
* `smart-leds-trait`
* `cortex-m`
* `circuit-playground-express`

I'm not really sure of lines 18, 24, and 26 in `lib.rs`. Using `self.pin.set_high().unwrap_or(());` was the only way I could figure out to a) get the warnings to go away, and b) typecheck. (Just doing `.unwrap()` caused an error).